### PR TITLE
(MODULES-7369) Update PE version requirement and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,23 @@
 #### Table of Contents
 
 1. [Description](#description)
-2. [Setup - The basics of getting started with mco_rpc](#setup)
-3. [Usage - Configuration options and additional functionality](#usage)
-5. [Limitations - OS compatibility, etc.](#limitations)
+1. [Requirements](#requirements)
+1. [Setup - The basics of getting started with mco_rpc](#setup)
+1. [Usage - Configuration options and additional functionality](#usage)
+1. [Limitations - OS compatibility, etc.](#limitations)
 
 ## Description
 
 The `mco_rpc` module contains a task to run installed rpc agents through Puppet
 Tasks with either bolt or the Puppet Orchestrator.
+
+## Requirements
+
+This module is compatible with Puppet Enterprise and Puppet Bolt.
+
+* To run tasks with Puppet Enterprise, PE 2017.3 or later must be installed on the machine from which you are running task commands. Machines receiving task requests must be Puppet agents.
+
+* To run tasks with Puppet Bolt, Bolt 0.5 or later must be installed on the machine from which you are running task commands. Machines receiving task requests must have SSH or WinRM services enabled.
 
 ## Setup
 

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 5.1.0 < 6.0.0"
     }
   ],
   "pdk-version": "1.1.0",

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,7 +2,7 @@ require 'puppet'
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
-require 'beaker/task_helper'
+require 'beaker-task_helper'
 
 run_puppet_install_helper
 install_ca_certs unless pe_install?


### PR DESCRIPTION
Updates Puppet version requirements to display a PE version requirement
of 2017.3+. Add a requirements section to the README consistent with
other task-only modules to describe requirements in more detail.